### PR TITLE
[NONPR-2371] add additional logging to shed light on why ES sometimes…

### DIFF
--- a/src/main/scala/uk/gov/hmrc/nonrep/attachment/service/Indexing.scala
+++ b/src/main/scala/uk/gov/hmrc/nonrep/attachment/service/Indexing.scala
@@ -25,12 +25,13 @@ import scala.concurrent.Future
 import scala.util.Try
 
 trait Request[A] {
-  def query(data: EitherErr[A])(implicit config: ServiceConfig): HttpRequest
+  def query(data: EitherErr[A])(implicit config: ServiceConfig, system: ActorSystem[_]): HttpRequest
 }
 
 trait Call[A] {
-  def run()(implicit system: ActorSystem[_], config: ServiceConfig)
-  : Flow[(HttpRequest, EitherErr[A]), (Try[HttpResponse], EitherErr[A]), Any]
+  def run()(
+    implicit system: ActorSystem[_],
+    config: ServiceConfig): Flow[(HttpRequest, EitherErr[A]), (Try[HttpResponse], EitherErr[A]), Any]
 }
 
 trait Response[A] {
@@ -40,7 +41,6 @@ trait Response[A] {
 trait Indexing[A] extends Request[A] with Call[A] with Response[A] {}
 
 object Indexing {
-
   object Request {
     def apply[A](implicit service: Request[A]): Request[A] = service
   }
@@ -56,12 +56,13 @@ object Indexing {
   object ops {
 
     implicit class RequestOps[A: Request](value: EitherErr[A]) {
-      def query()(implicit config: ServiceConfig): HttpRequest = Request[A].query(value)
+      def query()(implicit config: ServiceConfig, system: ActorSystem[_]): HttpRequest = Request[A].query(value)
     }
 
     implicit class CallOps[A: Call](value: EitherErr[A]) {
-      def flow()(implicit system: ActorSystem[_], config: ServiceConfig)
-      : Flow[(HttpRequest, EitherErr[A]), (Try[HttpResponse], EitherErr[A]), Any] = Call[A].run()
+      def flow()(
+        implicit system: ActorSystem[_],
+        config: ServiceConfig): Flow[(HttpRequest, EitherErr[A]), (Try[HttpResponse], EitherErr[A]), Any] = Call[A].run()
     }
 
     implicit class ResponseOps[A: Response](value: EitherErr[A]) {
@@ -72,32 +73,37 @@ object Indexing {
   }
 
   implicit val defaultIndexingService: Indexing[AttachmentRequestKey] = new Indexing[AttachmentRequestKey] {
-    override def run()(implicit system: ActorSystem[_], config: ServiceConfig):
-    Flow[(HttpRequest, EitherErr[AttachmentRequestKey]), (Try[HttpResponse], EitherErr[AttachmentRequestKey]), Any] =
+    override def run()(implicit system: ActorSystem[_], config: ServiceConfig)
+      : Flow[(HttpRequest, EitherErr[AttachmentRequestKey]), (Try[HttpResponse], EitherErr[AttachmentRequestKey]), Any] =
       if (config.isElasticSearchProtocolSecure)
         Http().cachedHostConnectionPoolHttps[EitherErr[AttachmentRequestKey]](config.elasticSearchHost)
       else
         Http().cachedHostConnectionPool[EitherErr[AttachmentRequestKey]](config.elasticSearchHost)
 
-    override def query(data: EitherErr[AttachmentRequestKey])(implicit config: ServiceConfig): HttpRequest = {
-      data
-        .toOption
+    override def query(data: EitherErr[AttachmentRequestKey])(implicit config: ServiceConfig, system: ActorSystem[_]): HttpRequest =
+      data.toOption
         .flatMap(value => config.notableEvents.get(value.apiKey).map(notableEvents => (value, notableEvents)))
         .map {
-          case (value, notableEvents) =>
+          case (attachmentRequestKey: AttachmentRequestKey, notableEvents) =>
             import RequestsSigner._
-            val path = buildPath(notableEvents)
-            val body = s"""{"query": {"bool":{"must":[{"match":{"attachmentIds.keyword":"${value.request.attachmentId}"}},{"ids":{"values":"${value.request.nrSubmissionId}"}}]}}}"""
-            createSignedRequest(HttpMethods.POST, config.elasticSearchUri, path, body)
-        }.getOrElse(HttpRequest())
-    }
 
-    override def parse(value: EitherErr[AttachmentRequestKey], response: HttpResponse)(implicit system: ActorSystem[_]): Future[EitherErr[AttachmentRequestKey]] = {
+            val path = buildPath(notableEvents)
+            val body =
+              s"""{"query": {"bool":{"must":[{"match":{"attachmentIds.keyword":"${attachmentRequestKey.request.attachmentId}"}},{"ids":{"values":"${attachmentRequestKey.request.nrSubmissionId}"}}]}}}"""
+            val request = createSignedRequest(HttpMethods.POST, config.elasticSearchUri, path, body)
+
+            system.log.info(
+              s"query for attachmentRequestKey: [$attachmentRequestKey] and notableEvents: [$notableEvents] produced path: [$path], body: [$body] and request: [$request]")
+
+            request
+        }
+        .getOrElse(HttpRequest())
+
+    override def parse(value: EitherErr[AttachmentRequestKey], response: HttpResponse)(
+      implicit system: ActorSystem[_]): Future[EitherErr[AttachmentRequestKey]] =
       if (response.status == StatusCodes.OK) {
         import system.executionContext
-        response
-          .entity
-          .dataBytes
+        response.entity.dataBytes
           .runFold(ByteString.empty)(_ ++ _)
           .map(_.utf8String)
           .map(_.parseJson)
@@ -105,11 +111,14 @@ object Indexing {
           .map(Right(_).withLeft[ErrorMessage])
           .map(_.filterOrElse(_.hits.total == 1, ErrorMessage("Invalid nrSubmissionId")).flatMap(_ => value))
       } else {
-        val error = ErrorMessage(s"Response status ${response.status} from ES server", StatusCodes.InternalServerError)
+        val error =
+          ErrorMessage(
+            s"Response status ${response.status} from ES server for request: [$value]. Full response is: [$response]",
+            StatusCodes.InternalServerError)
+
         response.discardEntityBytes()
         Future.successful(Left(error))
       }
-    }
   }
 
   def buildPath(notableEvent: Set[String]) = s"/${notableEvent.map(_.concat("-attachments")).mkString(",")}/_search"
@@ -118,7 +127,12 @@ object Indexing {
 object RequestsSigner {
   private lazy val signer = Aws4Signer.create()
 
-  def createSignedRequest(method: HttpMethod, uri: URI, path: String, body: String, credsProvider: AwsCredentialsProvider = DefaultCredentialsProvider.create()): HttpRequest = {
+  def createSignedRequest(
+    method: HttpMethod,
+    uri: URI,
+    path: String,
+    body: String,
+    credsProvider: AwsCredentialsProvider = DefaultCredentialsProvider.create()): HttpRequest = {
 
     import scala.jdk.CollectionConverters._
 

--- a/src/main/scala/uk/gov/hmrc/nonrep/attachment/service/Indexing.scala
+++ b/src/main/scala/uk/gov/hmrc/nonrep/attachment/service/Indexing.scala
@@ -111,10 +111,9 @@ object Indexing {
           .map(Right(_).withLeft[ErrorMessage])
           .map(_.filterOrElse(_.hits.total == 1, ErrorMessage("Invalid nrSubmissionId")).flatMap(_ => value))
       } else {
-        val error =
-          ErrorMessage(
-            s"Response status ${response.status} from ES server for request: [$value]. Full response is: [$response]",
-            StatusCodes.InternalServerError)
+        system.log.error(s"Response status ${response.status} received rom ES server for request: [$value]. Full response is: [$response]")
+
+        val error = ErrorMessage(s"Response status ${response.status} from ES server", StatusCodes.InternalServerError)
 
         response.discardEntityBytes()
         Future.successful(Left(error))

--- a/src/test/scala/uk/gov/hmrc/nonrep/attachment/TestServices.scala
+++ b/src/test/scala/uk/gov/hmrc/nonrep/attachment/TestServices.scala
@@ -28,7 +28,7 @@ object TestServices {
 
   object success {
     implicit val successfulIndexing: Indexing[AttachmentRequestKey] = new Indexing[AttachmentRequestKey]() {
-      override def query(data: EitherErr[AttachmentRequestKey])(implicit config: ServiceConfig): HttpRequest =
+      override def query(data: EitherErr[AttachmentRequestKey])(implicit config: ServiceConfig, system: ActorSystem[_]): HttpRequest =
         data.toOption.map { value =>
           val path = Indexing.buildPath(config.notableEvents(value.apiKey))
           val body = s"""{"query": {"bool":{"must":[{"match":{"attachmentIds":"${value.request.attachmentId}"}},{"ids":{"values":"${value.request.nrSubmissionId}"}}]}}}"""
@@ -49,7 +49,7 @@ object TestServices {
 
   object failure {
     implicit val indexingWithUpstreamFailureAndParsingError: Indexing[AttachmentRequestKey] = new Indexing[AttachmentRequestKey]() {
-      override def query(data: EitherErr[AttachmentRequestKey])(implicit config: ServiceConfig): HttpRequest =
+      override def query(data: EitherErr[AttachmentRequestKey])(implicit config: ServiceConfig, system: ActorSystem[_]): HttpRequest =
         data.toOption.map { value =>
           val path = Indexing.buildPath(config.notableEvents(value.apiKey))
           val body = s"""{"query": {"bool":{"must":[{"match":{"attachmentIds":"${value.request.attachmentId}"}},{"ids":{"values":"${value.request.nrSubmissionId}"}}]}}}"""


### PR DESCRIPTION
… returns 404

```
sbt test
...
[info] Run completed in 3 seconds, 15 milliseconds.
[info] Total number of tests run: 22
[info] Suites: completed 5, aborted 0
[info] Tests: succeeded 22, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 9 s, completed 12-Nov-2021 13:44:27
```

```
sbt it:test
...
[info] Run completed in 3 seconds, 250 milliseconds.
[info] Total number of tests run: 6
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 6, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 5 s, completed 12-Nov-2021 13:45:04
```